### PR TITLE
Add SI detail page scraping

### DIFF
--- a/handelsregister.py
+++ b/handelsregister.py
@@ -12,12 +12,31 @@ import pathlib
 import sys
 from bs4 import BeautifulSoup
 import urllib.parse
+import xml.etree.ElementTree as ET
 
 # Dictionaries to map arguments to values
 schlagwortOptionen = {
     "all": 1,
     "min": 2,
     "exact": 3
+}
+
+# XJustiz namespace
+NS = {'tns': 'http://www.xjustiz.de'}
+
+# Role code to label mapping (from xjustiz codeliste:gds.rollenbezeichnung)
+ROLE_CODES = {
+    '086': 'Geschäftsführer(in)',
+    '087': 'Vorstand',
+    '285': 'Prokurist(in)',
+    '287': 'Rechtsträger(in)',
+    '288': 'Registergericht',
+    '215': 'Einreicher(in)',
+    '061': 'Gesellschafter(in)',
+    '062': 'Kommanditist(in)',
+    '063': 'Persönlich haftende(r) Gesellschafter(in)',
+    '089': 'Liquidator(in)',
+    '297': 'Inhaber(in)',
 }
 
 class HandelsRegister:
@@ -49,7 +68,7 @@ class HandelsRegister:
             ),
             (   "Connection", "keep-alive"    ),
         ]
-        
+
         self.cachedir = pathlib.Path(tempfile.gettempdir()) / "handelsregister_cache"
         self.cachedir.mkdir(parents=True, exist_ok=True)
 
@@ -96,8 +115,294 @@ class HandelsRegister:
             # TODO catch the situation if there's more than one company?
             # TODO get all documents attached to the exact company
             # TODO parse useful information out of the PDFs
+        self._last_search_html = html
         return get_companies_in_searchresults(html)
 
+    def fetch_company_detail(self, result_index=0):
+        """Fetch the SI (Strukturierter Registerinhalt) document for a search result.
+
+        Must be called after search_company(). Uses the cached search HTML to find
+        the SI link's PrimeFaces submit params, then submits the form to fetch the
+        XML document.
+
+        Returns a dict of parsed company detail fields, or None if SI is unavailable.
+        """
+        html = self._last_search_html
+        soup = BeautifulSoup(html, 'html.parser')
+
+        # Find the SI link for the given result index
+        si_link = None
+        for a in soup.find_all('a'):
+            link_id = a.get('id', '')
+            # Match pattern: ergebnissForm:selectedSuchErgebnisFormTable:{index}:...:fade_
+            if ':{}:'.format(result_index) in link_id:
+                span = a.find('span')
+                if span and span.text.strip() == 'SI':
+                    si_link = a
+                    break
+
+        if not si_link:
+            return None
+
+        onclick = si_link.get('onclick', '')
+        if not onclick:
+            return None
+
+        # Parse PrimeFaces.addSubmitParam params from onclick
+        pairs = re.findall(r"'([^']+)':'([^']*)'", onclick)
+        if not pairs:
+            return None
+
+        # Select the ergebnissForm and inject hidden params
+        self.browser.select_form(name='ergebnissForm')
+        for key, value in pairs:
+            self.browser.form.new_control('hidden', key, {'value': value})
+        self.browser.form.fixup()
+
+        response_si = self.browser.submit()
+        si_xml = response_si.read().decode('utf-8')
+
+        # Cache the SI XML
+        cachename = self.companyname2cachename(self.args.schlagwoerter + '_SI')
+        with open(cachename, 'w') as f:
+            f.write(si_xml)
+
+        return parse_si_detail(si_xml)
+
+
+def _build_comment_map(xml_str):
+    """Build a map from XML element code values to their preceding comments.
+
+    XJustiz uses XML comments to provide human-readable labels for coded values, e.g.:
+      <!--Gesellschaft mit beschränkter Haftung (GmbH)--><code>221110</code>
+    ElementTree drops comments during parsing, so we extract them from the raw string.
+    """
+    comment_map = {}
+    for match in re.finditer(r'<!--(.+?)-->\s*<code>([^<]+)</code>', xml_str):
+        comment_map[match.group(2)] = match.group(1)
+    return comment_map
+
+
+def parse_si_detail(xml_str):
+    """Parse the SI (Strukturierter Registerinhalt) XJustiz XML into a dict.
+
+    The SI document is an XJustiz XML file containing structured register content:
+    company name, address, legal form, capital, directors, prokura holders, etc.
+    """
+    root = ET.fromstring(xml_str)
+    comment_map = _build_comment_map(xml_str)
+    detail = {}
+
+    # Build a role-number-to-person/org mapping from beteiligung entries
+    roles = {}  # rollennummer -> {role_code, role_label, person_data}
+    for beteiligung in root.findall('.//tns:beteiligung', NS):
+        rolle_elems = beteiligung.findall('tns:rolle', NS)
+        beteiligter = beteiligung.find('tns:beteiligter', NS)
+        if beteiligter is None:
+            continue
+
+        for rolle in rolle_elems:
+            rollennummer = _text(rolle, 'tns:rollennummer')
+            role_code_elem = rolle.find('tns:rollenbezeichnung', NS)
+            role_code = _text(role_code_elem, 'code') if role_code_elem is not None else None
+            role_label = ROLE_CODES.get(role_code, comment_map.get(role_code, role_code))
+
+            person_data = _parse_beteiligter(beteiligter, comment_map)
+            if rollennummer:
+                roles[rollennummer] = {
+                    'role_code': role_code,
+                    'role_label': role_label,
+                    **person_data
+                }
+
+    # Company info from the Rechtsträger (role code 287)
+    for rnum, rdata in roles.items():
+        if rdata.get('role_code') == '287':
+            detail['name'] = rdata.get('name')
+            detail['legal_form'] = rdata.get('legal_form')
+            detail['legal_form_code'] = rdata.get('legal_form_code')
+            detail['seat'] = rdata.get('seat')
+            if rdata.get('address'):
+                detail['address'] = rdata['address']
+            break
+
+    # basisdatenRegister
+    basisdaten = root.find('.//tns:basisdatenRegister', NS)
+    if basisdaten is not None:
+        # Satzungsdatum
+        satzung = basisdaten.find('.//tns:aktuellesSatzungsdatum', NS)
+        if satzung is not None and satzung.text:
+            detail['articles_of_association_date'] = satzung.text
+
+        # Gegenstand (business purpose)
+        gegenstand = basisdaten.find('.//tns:gegenstand', NS)
+        if gegenstand is not None and gegenstand.text:
+            detail['business_purpose'] = gegenstand.text.strip()
+
+        # Vertretungsregelung (representation rules)
+        allg_vertretung = basisdaten.find('.//tns:allgemeineVertretungsregelung', NS)
+        if allg_vertretung is not None:
+            vb = allg_vertretung.find('.//tns:vertretungsbefugnis', NS)
+            if vb is not None:
+                vb_code = _text(vb, 'code')
+                if vb_code and vb_code in comment_map:
+                    detail['representation_rules'] = comment_map[vb_code]
+
+        # Representatives with their specific rules
+        for vb_elem in basisdaten.findall('.//tns:vertretungsberechtigte', NS):
+            ref = _text(vb_elem, 'tns:ref.rollennummer')
+            if ref and ref in roles:
+                rep = roles[ref]
+                besondere = vb_elem.find('tns:besondereVertretungsregelung', NS)
+                if besondere is not None:
+                    freitext = besondere.find('.//tns:vertretungsbefugnisFreitext', NS)
+                    if freitext is not None and freitext.text:
+                        rep['representation'] = freitext.text.strip().rstrip(';')
+                    else:
+                        vb_code_elem = besondere.find('.//tns:vertretungsbefugnis', NS)
+                        if vb_code_elem is not None:
+                            code_val = _text(vb_code_elem, 'code')
+                            if code_val and code_val in comment_map:
+                                rep['representation'] = comment_map[code_val]
+
+                    befreiung = besondere.find('.//tns:befreiungVon181BGB', NS)
+                    if befreiung is not None:
+                        rep['exempt_181_bgb'] = True
+
+    # Collect managing directors and prokura holders
+    directors = []
+    prokura = []
+    for rnum, rdata in roles.items():
+        if rdata.get('role_code') == '086':  # Geschäftsführer
+            directors.append(rdata)
+        elif rdata.get('role_code') == '087':  # Vorstand
+            directors.append(rdata)
+        elif rdata.get('role_code') == '285':  # Prokurist
+            prokura.append(rdata)
+
+    if directors:
+        detail['directors'] = directors
+    if prokura:
+        detail['prokura'] = prokura
+
+    # Capital (Stammkapital / Grundkapital)
+    stammkapital = root.find('.//tns:stammkapital', NS)
+    if stammkapital is None:
+        stammkapital = root.find('.//tns:grundkapital', NS)
+    if stammkapital is not None:
+        zahl = _text(stammkapital, 'tns:zahl')
+        waehrung_elem = stammkapital.find('.//tns:waehrung', NS)
+        waehrung_code = _text(waehrung_elem, 'code') if waehrung_elem is not None else None
+        if zahl:
+            detail['capital'] = {
+                'amount': zahl,
+                'currency': waehrung_code or 'EUR'
+            }
+
+    # Register info
+    aktenzeichen = root.find('.//tns:aktenzeichen.strukturiert', NS)
+    if aktenzeichen is not None:
+        register = aktenzeichen.find('tns:register', NS)
+        nummer = _text(aktenzeichen, 'tns:laufendeNummer')
+        if register is not None and nummer:
+            reg_code = _text(register, 'code')
+            detail['register_type'] = reg_code
+            detail['register_number'] = nummer
+
+    # Auszug metadata
+    auszug = root.find('.//tns:auszug', NS)
+    if auszug is not None:
+        detail['retrieval_date'] = _text(auszug, 'tns:abrufdatum')
+        detail['last_entry_date'] = _text(auszug, 'tns:letzteEintragung')
+        detail['num_entries'] = _text(auszug, 'tns:anzahlEintragungen')
+
+    # Eintragungstexte (register entry texts)
+    entries = []
+    for et_elem in root.findall('.//tns:eintragungstext', NS):
+        entry = {}
+        entry['column'] = _text(et_elem, 'tns:spalte')
+        entry['position'] = _text(et_elem, 'tns:position')
+        entry['number'] = _text(et_elem, 'tns:laufendeNummer')
+        entry['text'] = _text(et_elem, 'tns:text')
+        art_elem = et_elem.find('tns:eintragungsart', NS)
+        if art_elem is not None:
+            art_code = _text(art_elem, 'code')
+            if art_code and art_code in comment_map:
+                entry['type'] = comment_map[art_code]
+        entries.append(entry)
+    if entries:
+        detail['register_entries'] = entries
+
+    return detail
+
+
+def _text(parent, path):
+    """Extract text from an XML element, or None."""
+    if parent is None:
+        return None
+    elem = parent.find(path, NS)
+    if elem is not None and elem.text:
+        return elem.text.strip()
+    return None
+
+
+def _parse_beteiligter(beteiligter, comment_map):
+    """Parse a beteiligter element into a person/org dict."""
+    data = {}
+
+    # Natural person
+    person = beteiligter.find('.//tns:natuerlichePerson', NS)
+    if person is not None:
+        vorname = _text(person, './/tns:vorname')
+        nachname = _text(person, './/tns:nachname')
+        if vorname and nachname:
+            data['name'] = '%s %s' % (vorname, nachname)
+        elif nachname:
+            data['name'] = nachname
+
+        geburtsdatum = _text(person, './/tns:geburtsdatum')
+        if geburtsdatum:
+            data['date_of_birth'] = geburtsdatum
+
+        anschrift = person.find('tns:anschrift', NS)
+        if anschrift is not None:
+            data['city'] = _text(anschrift, 'tns:ort')
+
+        return data
+
+    # Organisation
+    org = beteiligter.find('.//tns:organisation', NS)
+    if org is not None:
+        data['name'] = _text(org, './/tns:bezeichnung.aktuell')
+
+        rechtsform = org.find('.//tns:rechtsform', NS)
+        if rechtsform is not None:
+            rf_code = _text(rechtsform, 'code')
+            if rf_code:
+                data['legal_form'] = comment_map.get(rf_code, rf_code)
+                data['legal_form_code'] = rf_code
+
+        sitz = org.find('tns:sitz', NS)
+        if sitz is not None:
+            data['seat'] = _text(sitz, 'tns:ort')
+
+        anschrift = org.find('tns:anschrift', NS)
+        if anschrift is not None:
+            addr = {}
+            street = _text(anschrift, 'tns:strasse')
+            hausnummer = _text(anschrift, 'tns:hausnummer')
+            if street:
+                addr['street'] = street + (' ' + hausnummer if hausnummer else '')
+            plz = _text(anschrift, 'tns:postleitzahl')
+            if plz:
+                addr['postal_code'] = plz
+            ort = _text(anschrift, 'tns:ort')
+            if ort:
+                addr['city'] = ort
+            if addr:
+                data['address'] = addr
+
+    return data
 
 
 def parse_result(result):
@@ -106,7 +411,7 @@ def parse_result(result):
         cells.append(cell.text.strip())
     d = {}
     d['court'] = cells[1]
-    
+
     # Extract register number: HRB, HRA, VR, GnR followed by numbers (e.g. HRB 12345, VR 6789)
     # Also capture suffix letter if present (e.g. HRB 12345 B), but avoid matching start of words (e.g. " Formerly")
     reg_match = re.search(r'(HRA|HRB|GnR|VR|PR)\s*\d+(\s+[A-Z])?(?!\w)', d['court'])
@@ -147,10 +452,65 @@ def pr_company_info(c):
     for name, loc in c.get('history'):
         print(name, loc)
 
+def pr_company_detail(detail):
+    """Print the SI detail fields in human-readable format."""
+    if not detail:
+        print('  (no detail data available)')
+        return
+
+    print()
+    print('--- Detail (SI) ---')
+    for key in ('name', 'legal_form', 'seat', 'business_purpose',
+                'articles_of_association_date', 'representation_rules'):
+        if key in detail:
+            label = key.replace('_', ' ').title()
+            print('%s: %s' % (label, detail[key]))
+
+    if 'address' in detail:
+        addr = detail['address']
+        parts = []
+        if 'street' in addr:
+            parts.append(addr['street'])
+        if 'postal_code' in addr and 'city' in addr:
+            parts.append('%s %s' % (addr['postal_code'], addr['city']))
+        elif 'city' in addr:
+            parts.append(addr['city'])
+        print('Address: %s' % ', '.join(parts))
+
+    if 'capital' in detail:
+        cap = detail['capital']
+        print('Capital: %s %s' % (cap['amount'], cap['currency']))
+
+    if 'directors' in detail:
+        print('Directors:')
+        for d in detail['directors']:
+            extra = ''
+            if d.get('representation'):
+                extra = ' (%s)' % d['representation']
+            print('  %s%s' % (d.get('name', '?'), extra))
+
+    if 'prokura' in detail:
+        print('Prokura:')
+        for p in detail['prokura']:
+            extra = ''
+            if p.get('representation'):
+                extra = ' (%s)' % p['representation']
+            print('  %s%s' % (p.get('name', '?'), extra))
+
+    if 'register_entries' in detail:
+        print('Register Entries:')
+        for entry in detail['register_entries']:
+            etype = entry.get('type', '')
+            text = entry.get('text', '')
+            print('  [%s] %s' % (etype, text))
+
+    print('Last Entry: %s' % detail.get('last_entry_date', '-'))
+    print('Retrieval Date: %s' % detail.get('retrieval_date', '-'))
+
 def get_companies_in_searchresults(html):
     soup = BeautifulSoup(html, 'html.parser')
     grid = soup.find('table', role='grid')
-  
+
     results = []
     for result in grid.find_all('tr'):
         a = result.get('data-ri')
@@ -195,6 +555,12 @@ def parse_args():
                           help="Return response as JSON",
                           action="store_true"
                         )
+    parser.add_argument(
+                          "-det",
+                          "--detail",
+                          help="Fetch SI (structured register content) detail for the first search result",
+                          action="store_true"
+                        )
     args = parser.parse_args()
 
 
@@ -214,8 +580,17 @@ if __name__ == "__main__":
     h.open_startpage()
     companies = h.search_company()
     if companies is not None:
+        detail = None
+        if args.detail and len(companies) > 0:
+            detail = h.fetch_company_detail(result_index=0)
+
         if args.json:
-            print(json.dumps(companies))
+            output = companies
+            if detail:
+                output[0]['detail'] = detail
+            print(json.dumps(output))
         else:
             for c in companies:
                 pr_company_info(c)
+            if detail:
+                pr_company_detail(detail)

--- a/test_handelsregister.py
+++ b/test_handelsregister.py
@@ -1,12 +1,12 @@
 import pytest
-from handelsregister import get_companies_in_searchresults,HandelsRegister
+from handelsregister import get_companies_in_searchresults,HandelsRegister,parse_si_detail
 import argparse
 
 def test_parse_search_result():
     html = '<html><body>%s</body></html>' % """<table role="grid"><thead></thead><tbody id="ergebnissForm:selectedSuchErgebnisFormTable_data" class="ui-datatable-data ui-widget-content"><tr data-ri="0" class="ui-widget-content ui-datatable-even" role="row"><td role="gridcell" colspan="9" class="borderBottom3"><table id="ergebnissForm:selectedSuchErgebnisFormTable:0:j_idt147" class="ui-panelgrid ui-widget" role="grid"><tbody><tr class="ui-widget-content ui-panelgrid-even borderBottom1" role="row"><td role="gridcell" class="ui-panelgrid-cell fontTableNameSize" colspan="5">Berlin  <span class="fontWeightBold"> District court Berlin (Charlottenburg) HRB 44343  </span></td></tr><tr class="ui-widget-content ui-panelgrid-odd" role="row"><td role="gridcell" class="ui-panelgrid-cell paddingBottom20Px" colspan="5"><span class="marginLeft20">GASAG AG</span></td><td role="gridcell" class="ui-panelgrid-cell sitzSuchErgebnisse"><span class="verticalText ">Berlin</span></td><td role="gridcell" class="ui-panelgrid-cell" style="text-align: center;padding-bottom: 20px;"><span class="verticalText">currently registered</span></td><td role="gridcell" class="ui-panelgrid-cell textAlignLeft paddingBottom20Px" colspan="2"><div id="ergebnissForm:selectedSuchErgebnisFormTable:0:j_idt160" class="ui-outputpanel ui-widget linksPanel"><script type="text/javascript" src="/rp_web/javax.faces.resource/jsf.js.xhtml?ln=javax.faces"></script><a id="ergebnissForm:selectedSuchErgebnisFormTable:0:j_idt161:0:fade" href="#" class="dokumentList" aria-describedby="ergebnissForm:selectedSuchErgebnisFormTable:0:j_idt161:0:toolTipFade"><span id="ergebnissForm:selectedSuchErgebnisFormTable:0:j_idt161:0:popupLink" class="underlinedText">AD</span></a><a id="ergebnissForm:selectedSuchErgebnisFormTable:0:j_idt161:1:fade" href="#" class="dokumentList" aria-describedby="ergebnissForm:selectedSuchErgebnisFormTable:0:j_idt161:1:toolTipFade"><span id="ergebnissForm:selectedSuchErgebnisFormTable:0:j_idt161:1:popupLink" class="underlinedText">CD</span></a><a id="ergebnissForm:selectedSuchErgebnisFormTable:0:j_idt161:2:fade" href="#" class="dokumentList" aria-describedby="ergebnissForm:selectedSuchErgebnisFormTable:0:j_idt161:2:toolTipFade"><span id="ergebnissForm:selectedSuchErgebnisFormTable:0:j_idt161:2:popupLink" class="underlinedText">HD</span></a><a id="ergebnissForm:selectedSuchErgebnisFormTable:0:j_idt161:3:fade" href="#" class="dokumentList" aria-describedby="ergebnissForm:selectedSuchErgebnisFormTable:0:j_idt161:3:toolTipFade"><span id="ergebnissForm:selectedSuchErgebnisFormTable:0:j_idt161:3:popupLink" class="underlinedText">DK</span></a><a id="ergebnissForm:selectedSuchErgebnisFormTable:0:j_idt161:4:fade" href="#" class="dokumentList" aria-describedby="ergebnissForm:selectedSuchErgebnisFormTable:0:j_idt161:4:toolTipFade"><span id="ergebnissForm:selectedSuchErgebnisFormTable:0:j_idt161:4:popupLink" class="underlinedText">UT</span></a><a id="ergebnissForm:selectedSuchErgebnisFormTable:0:j_idt161:5:fade" href="#" class="dokumentList" aria-describedby="ergebnissForm:selectedSuchErgebnisFormTable:0:j_idt161:5:toolTipFade"><span id="ergebnissForm:selectedSuchErgebnisFormTable:0:j_idt161:5:popupLink" class="underlinedText">VÖ</span></a><a id="ergebnissForm:selectedSuchErgebnisFormTable:0:j_idt161:6:fade" href="#" class="dokumentList" aria-describedby="ergebnissForm:selectedSuchErgebnisFormTable:0:j_idt161:6:toolTipFade"><span id="ergebnissForm:selectedSuchErgebnisFormTable:0:j_idt161:6:popupLink" class="underlinedText">SI</span></a></div></td></tr><tr class="ui-widget-content ui-panelgrid-even" role="row"><td role="gridcell" class="ui-panelgrid-cell" colspan="7"><table id="ergebnissForm:selectedSuchErgebnisFormTable:0:j_idt172" class="ui-panelgrid ui-widget marginLeft20" role="grid"><tbody><tr class="ui-widget-content ui-panelgrid-even borderBottom1 RegPortErg_Klein" role="row"><td role="gridcell" class="ui-panelgrid-cell padding0Px">History</td></tr></tbody></table><table id="ergebnissForm:selectedSuchErgebnisFormTable:0:j_idt176" class="ui-panelgrid ui-widget" role="grid"><tbody><tr class="ui-widget-content" role="row"><td role="gridcell" class="ui-panelgrid-cell RegPortErg_HistorieZn marginLeft20 padding0Px" colspan="5"><span class="marginLeft20 fontSize85">1.) Gasag Berliner Gaswerke Aktiengesellschaft</span></td><td role="gridcell" class="ui-panelgrid-cell RegPortErg_SitzStatus "><span class="fontSize85">1.) Berlin</span></td><td role="gridcell" class="ui-panelgrid-cell textAlignCenter"></td></tr></tbody></table></td></tr></tbody></table></td></tr></tbody></table>"""
     res = get_companies_in_searchresults(html)
     assert res == [{
-            'court':'Berlin   District court Berlin (Charlottenburg) HRB 44343', 
+            'court':'Berlin   District court Berlin (Charlottenburg) HRB 44343',
             'register_num': 'HRB 44343 B',
             'name':'GASAG AG',
             'state':'Berlin',
@@ -15,6 +15,75 @@ def test_parse_search_result():
             'documents': 'ADCDHDDKUTVÖSI',
             'history':[('1.) Gasag Berliner Gaswerke Aktiengesellschaft', '1.) Berlin')]
             },]
+
+
+def test_parse_si_detail():
+    """Test parsing of SI (Strukturierter Registerinhalt) XJustiz XML."""
+    si_xml = """<?xml version="1.0"?><tns:nachricht.reg.0400003 xmlns:tns="http://www.xjustiz.de" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><tns:nachrichtenkopf xjustizVersion="3.5.1"><tns:aktenzeichen.absender/><tns:aktenzeichen.empfaenger>unbekannt</tns:aktenzeichen.empfaenger><tns:erstellungszeitpunkt>2026-02-25T11:21:36Z</tns:erstellungszeitpunkt><tns:auswahl_absender><tns:absender.gericht listVersionID="3.5" listURI="urn:xoev-de:xjustiz:codeliste:gds.gerichte"><!--Amtsgericht Leipzig--><code>U1308</code></tns:absender.gericht></tns:auswahl_absender><tns:auswahl_empfaenger><tns:empfaenger.sonstige/></tns:auswahl_empfaenger><tns:eigeneNachrichtenID>test-id</tns:eigeneNachrichtenID><tns:ereignis listVersionID="1.5" listURI="urn:xoev-de:xjustiz:codeliste:gds.ereignis"><!--HR-Auszug--><code>002</code></tns:ereignis><tns:herstellerinformation><tns:nameDesProdukts>RegisSTAR</tns:nameDesProdukts><tns:herstellerDesProdukts>Test</tns:herstellerDesProdukts><tns:version>1.0</tns:version></tns:herstellerinformation></tns:nachrichtenkopf><tns:grunddaten><tns:verfahrensdaten><tns:instanzdaten><tns:instanznummer>0</tns:instanznummer><tns:auswahl_instanzbehoerde><tns:gericht listVersionID="3.5" listURI="urn:xoev-de:xjustiz:codeliste:gds.gerichte"><!--Amtsgericht Leipzig--><code>U1308</code></tns:gericht></tns:auswahl_instanzbehoerde><tns:aktenzeichen><tns:auswahl_aktenzeichen><tns:aktenzeichen.strukturiert><tns:register listVersionID="3.4" listURI="urn:xoev-de:xjustiz:codeliste:gds.registerzeichen"><!--HRB--><code>HRB</code></tns:register><tns:laufendeNummer>32007</tns:laufendeNummer><tns:jahr/></tns:aktenzeichen.strukturiert></tns:auswahl_aktenzeichen></tns:aktenzeichen><tns:verfahrensgegenstand><tns:gegenstand>Strukturierter Registerinhalt</tns:gegenstand></tns:verfahrensgegenstand></tns:instanzdaten><tns:beteiligung><tns:rolle><tns:rollennummer>1</tns:rollennummer><tns:rollenID><tns:id>145365283</tns:id><tns:ref.instanznummer>0</tns:ref.instanznummer></tns:rollenID><tns:rollenbezeichnung listVersionID="3.3" listURI="urn:xoev-de:xjustiz:codeliste:gds.rollenbezeichnung"><!--Rechtsträger(in)--><code>287</code></tns:rollenbezeichnung></tns:rolle><tns:beteiligter><tns:beteiligtennummer>1</tns:beteiligtennummer><tns:auswahl_beteiligter><tns:organisation><tns:bezeichnung><tns:bezeichnung.aktuell>Test Company GmbH</tns:bezeichnung.aktuell></tns:bezeichnung><tns:angabenZurRechtsform><tns:rechtsform listVersionID="2.2" listURI="urn:xoev-de:xunternehmen:codeliste:rechtsformen"><!--Gesellschaft mit beschränkter Haftung (GmbH)--><code>221110</code></tns:rechtsform></tns:angabenZurRechtsform><tns:sitz><tns:ort>Leipzig</tns:ort></tns:sitz><tns:anschrift><tns:anschriftstyp listVersionID="3.0" listURI="urn:xoev-de:xjustiz:codeliste:gds.anschriftstyp"><!--Dienst-/Geschäftsanschrift--><code>003</code></tns:anschriftstyp><tns:strasse>Teststraße</tns:strasse><tns:hausnummer>42</tns:hausnummer><tns:postleitzahl>04109</tns:postleitzahl><tns:ort>Leipzig</tns:ort><tns:staat listVersionID="6.1" listURI="urn:xoev-de:bund:bfj:codeliste:bfj.staat"><!--Deutschland--><code>000</code></tns:staat></tns:anschrift></tns:organisation></tns:auswahl_beteiligter></tns:beteiligter></tns:beteiligung><tns:beteiligung><tns:rolle><tns:rollennummer>4</tns:rollennummer><tns:rollenID><tns:id>145332515</tns:id><tns:ref.instanznummer>0</tns:ref.instanznummer></tns:rollenID><tns:rollenbezeichnung listVersionID="3.3" listURI="urn:xoev-de:xjustiz:codeliste:gds.rollenbezeichnung"><!--Geschäftsführer(in)--><code>086</code></tns:rollenbezeichnung></tns:rolle><tns:beteiligter><tns:beteiligtennummer>4</tns:beteiligtennummer><tns:auswahl_beteiligter><tns:natuerlichePerson><tns:vollerName><tns:vorname>Max</tns:vorname><tns:nachname>Mustermann</tns:nachname></tns:vollerName><tns:geburt><tns:geburtsdatum>1984-06-25</tns:geburtsdatum></tns:geburt><tns:anschrift><tns:anschriftstyp listVersionID="3.0" listURI="urn:xoev-de:xjustiz:codeliste:gds.anschriftstyp"><!--Privatanschrift--><code>017</code></tns:anschriftstyp><tns:ort>Leipzig</tns:ort></tns:anschrift></tns:natuerlichePerson></tns:auswahl_beteiligter></tns:beteiligter></tns:beteiligung><tns:beteiligung><tns:rolle><tns:rollennummer>5</tns:rollennummer><tns:rollenID><tns:id>145435568</tns:id><tns:ref.instanznummer>0</tns:ref.instanznummer></tns:rollenID><tns:rollenbezeichnung listVersionID="3.3" listURI="urn:xoev-de:xjustiz:codeliste:gds.rollenbezeichnung"><!--Prokurist(in)--><code>285</code></tns:rollenbezeichnung></tns:rolle><tns:beteiligter><tns:beteiligtennummer>5</tns:beteiligtennummer><tns:auswahl_beteiligter><tns:natuerlichePerson><tns:vollerName><tns:vorname>Erika</tns:vorname><tns:nachname>Musterfrau</tns:nachname></tns:vollerName><tns:geburt><tns:geburtsdatum>1990-01-15</tns:geburtsdatum></tns:geburt><tns:anschrift><tns:anschriftstyp listVersionID="3.0" listURI="urn:xoev-de:xjustiz:codeliste:gds.anschriftstyp"><!--Privatanschrift--><code>017</code></tns:anschriftstyp><tns:ort>Berlin</tns:ort></tns:anschrift></tns:natuerlichePerson></tns:auswahl_beteiligter></tns:beteiligter></tns:beteiligung></tns:verfahrensdaten></tns:grunddaten><tns:schriftgutobjekte/><tns:fachdatenRegister fachdatenRegisterVersion="3.4"><tns:mitteilungsart listVersionID="1.5" listURI="urn:xoev-de:xjustiz:codeliste:gds.ereignis"><!--HR-Auszug--><code>002</code></tns:mitteilungsart><tns:betroffenerRechtstraeger><tns:ref.rollennummer>1</tns:ref.rollennummer></tns:betroffenerRechtstraeger><tns:auszug><tns:eintragungstext><tns:spalte>6</tns:spalte><tns:position>1</tns:position><tns:laufendeNummer>2</tns:laufendeNummer><tns:eintragungsart listVersionID="1.1" listURI="urn:xoev-de:xjustiz:codeliste:reg.eintragungstyp"><!--Satzung--><code>009</code></tns:eintragungsart><tns:text>Gesellschaftsvertrag vom 18.06.2015.</tns:text></tns:eintragungstext><tns:abrufuhrzeit>11:21:36</tns:abrufuhrzeit><tns:abrufdatum>2026-02-25</tns:abrufdatum><tns:letzteEintragung>2025-06-02</tns:letzteEintragung><tns:anzahlEintragungen>7</tns:anzahlEintragungen><tns:letzteAenderung><tns:aenderungsdatum>2025-05-22</tns:aenderungsdatum></tns:letzteAenderung></tns:auszug><tns:basisdatenRegister><tns:satzungsdatum><tns:aktuellesSatzungsdatum>2015-06-18</tns:aktuellesSatzungsdatum></tns:satzungsdatum><tns:rechtstraeger><tns:bezeichnung><tns:bezeichnung.aktuell>Test Company GmbH</tns:bezeichnung.aktuell></tns:bezeichnung><tns:angabenZurRechtsform><tns:rechtsform listVersionID="2.2" listURI="urn:xoev-de:xunternehmen:codeliste:rechtsformen"><!--Gesellschaft mit beschränkter Haftung (GmbH)--><code>221110</code></tns:rechtsform></tns:angabenZurRechtsform><tns:sitz><tns:ort>Leipzig</tns:ort></tns:sitz><tns:anschrift><tns:anschriftstyp listVersionID="3.0" listURI="urn:xoev-de:xjustiz:codeliste:gds.anschriftstyp"><!--Dienst-/Geschäftsanschrift--><code>003</code></tns:anschriftstyp><tns:strasse>Teststraße</tns:strasse><tns:hausnummer>42</tns:hausnummer><tns:postleitzahl>04109</tns:postleitzahl><tns:ort>Leipzig</tns:ort><tns:staat listVersionID="6.1" listURI="urn:xoev-de:bund:bfj:codeliste:bfj.staat"><!--Deutschland--><code>000</code></tns:staat></tns:anschrift></tns:rechtstraeger><tns:vertretung><tns:allgemeineVertretungsregelung><tns:auswahl_vertretungsbefugnis><tns:vertretungsbefugnis listVersionID="2.3" listURI="urn:xoev-de:xjustiz:codeliste:reg.allgemeine-vertretungsregelung"><!--Ist nur ein Geschäftsführer bestellt, so vertritt er die Gesellschaft allein.--><code>066</code></tns:vertretungsbefugnis></tns:auswahl_vertretungsbefugnis></tns:allgemeineVertretungsregelung><tns:vertretungsberechtigte><tns:ref.rollennummer>4</tns:ref.rollennummer><tns:besondereVertretungsregelung><tns:auswahl_vertretungsbefugnis><tns:vertretungsbefugnisFreitext>einzelvertretungsberechtigt;</tns:vertretungsbefugnisFreitext></tns:auswahl_vertretungsbefugnis><tns:auswahl_befreiungVon181BGB><tns:befreiungVon181BGB listVersionID="2.0" listURI="urn:xoev-de:xjustiz:codeliste:reg.besondere-befreiung"><!--mit der Befugnis Rechtsgeschäfte abzuschließen--><code>011</code></tns:befreiungVon181BGB></tns:auswahl_befreiungVon181BGB></tns:besondereVertretungsregelung></tns:vertretungsberechtigte><tns:vertretungsberechtigte><tns:ref.rollennummer>5</tns:ref.rollennummer><tns:besondereVertretungsregelung><tns:auswahl_vertretungsbefugnis><tns:vertretungsbefugnis listVersionID="2.3" listURI="urn:xoev-de:xjustiz:codeliste:reg.besondere-vertretungsregelung"><!--Einzelprokura--><code>002</code></tns:vertretungsbefugnis></tns:auswahl_vertretungsbefugnis></tns:besondereVertretungsregelung></tns:vertretungsberechtigte></tns:vertretung><tns:gegenstand>Softwareentwicklung und IT-Beratung.</tns:gegenstand><tns:geschaeftszweck/></tns:basisdatenRegister><tns:auswahl_zusatzangaben><tns:kapitalgesellschaft><tns:zusatzGmbH><tns:stammkapital><tns:zahl>25000.00</tns:zahl><tns:auswahl_waehrung><tns:waehrung listVersionID="1.0" listURI="urn:xoev-de:bund:kba:codeliste:waehrung"><!--Euro--><code>EUR</code></tns:waehrung></tns:auswahl_waehrung></tns:stammkapital></tns:zusatzGmbH></tns:kapitalgesellschaft></tns:auswahl_zusatzangaben></tns:fachdatenRegister></tns:nachricht.reg.0400003>"""
+
+    detail = parse_si_detail(si_xml)
+
+    # Company info
+    assert detail['name'] == 'Test Company GmbH'
+    assert 'GmbH' in detail['legal_form']
+    assert detail['seat'] == 'Leipzig'
+
+    # Address
+    assert detail['address']['street'] == 'Teststraße 42'
+    assert detail['address']['postal_code'] == '04109'
+    assert detail['address']['city'] == 'Leipzig'
+
+    # Business purpose
+    assert 'Softwareentwicklung' in detail['business_purpose']
+
+    # Capital
+    assert detail['capital']['amount'] == '25000.00'
+    assert detail['capital']['currency'] == 'EUR'
+
+    # Directors
+    assert len(detail['directors']) == 1
+    assert detail['directors'][0]['name'] == 'Max Mustermann'
+    assert detail['directors'][0]['date_of_birth'] == '1984-06-25'
+
+    # Prokura
+    assert len(detail['prokura']) == 1
+    assert detail['prokura'][0]['name'] == 'Erika Musterfrau'
+
+    # Register info
+    assert detail['register_type'] == 'HRB'
+    assert detail['register_number'] == '32007'
+    assert detail['retrieval_date'] == '2026-02-25'
+    assert detail['last_entry_date'] == '2025-06-02'
+
+    # Articles of association
+    assert detail['articles_of_association_date'] == '2015-06-18'
+
+    # Register entries
+    assert len(detail['register_entries']) >= 1
+    assert 'Gesellschaftsvertrag' in detail['register_entries'][0]['text']
+
+
+def test_fetch_detail():
+    """Integration test: search for a known company and fetch its SI data."""
+    args = argparse.Namespace(debug=False, force=True, schlagwoerter='Gecko Two GmbH',
+                              schlagwortOptionen='exact', json=False, detail=True)
+    h = HandelsRegister(args)
+    h.open_startpage()
+    companies = h.search_company()
+    assert companies is not None
+    assert len(companies) > 0
+
+    detail = h.fetch_company_detail(result_index=0)
+    assert detail is not None
+
+    # Basic fields that should always be present
+    assert detail.get('name') is not None
+    assert 'Gecko' in detail['name']
+    assert detail.get('seat') is not None
+    assert detail.get('address') is not None
+    assert detail.get('capital') is not None
+    assert detail.get('directors') is not None
+    assert len(detail['directors']) > 0
 
 
 @pytest.mark.parametrize("company, state_id", [
@@ -37,7 +106,7 @@ def test_parse_search_result():
 ])
 def test_search_by_state_company(company, state_id):
 
-    args = argparse.Namespace(debug=False, force=True, schlagwoerter=company, schlagwortOptionen='all', json=False)
+    args = argparse.Namespace(debug=False, force=True, schlagwoerter=company, schlagwortOptionen='all', json=False, detail=False)
     h = HandelsRegister(args)
     h.open_startpage()
     companies = h.search_company()
@@ -45,13 +114,13 @@ def test_search_by_state_company(company, state_id):
     assert len(companies) > 0
 
 def test_haus_anker_b_suffix():
-    args = argparse.Namespace(debug=False, force=True, schlagwoerter='Haus-Anker Verwaltungs GmbH', schlagwortOptionen='exact', json=False)
+    args = argparse.Namespace(debug=False, force=True, schlagwoerter='Haus-Anker Verwaltungs GmbH', schlagwortOptionen='exact', json=False, detail=False)
     h = HandelsRegister(args)
     h.open_startpage()
     companies = h.search_company()
     assert companies is not None
-     
+
     target_company = next((c for c in companies if '138434' in c['register_num']), None)
-    
+
     assert target_company is not None, "Haus-Anker Verwaltungs GmbH with expected number not found"
     assert target_company['register_num'] == 'HRB 138434 B'

--- a/web.py
+++ b/web.py
@@ -18,7 +18,7 @@ HTML = """<!DOCTYPE html>
 <style>
   * { box-sizing: border-box; margin: 0; padding: 0; }
   body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-         background: #f5f5f5; color: #222; padding: 2rem; max-width: 900px; margin: 0 auto; }
+         background: #f5f5f5; color: #222; padding: 2rem; max-width: 960px; margin: 0 auto; }
   h1 { margin-bottom: 1.5rem; font-size: 1.4rem; }
   form { background: #fff; padding: 1.5rem; border-radius: 8px; box-shadow: 0 1px 3px rgba(0,0,0,.1);
          display: flex; flex-wrap: wrap; gap: 1rem; align-items: end; margin-bottom: 2rem; }
@@ -34,7 +34,13 @@ HTML = """<!DOCTYPE html>
   #status { font-size: .85rem; color: #666; margin-bottom: 1rem; min-height: 1.2em; }
   #results { display: flex; flex-direction: column; gap: 1.5rem; }
   .card { background: #fff; padding: 1.2rem 1.5rem; border-radius: 8px; box-shadow: 0 1px 3px rgba(0,0,0,.1); }
-  .card h2 { font-size: 1.1rem; margin-bottom: .6rem; color: #0066cc; }
+  .card h2 { font-size: 1.2rem; margin-bottom: .8rem; color: #0066cc; }
+  .key-facts { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+               gap: .6rem; margin-bottom: 1rem; padding: .8rem; background: #f8fafc;
+               border-radius: 6px; border: 1px solid #e2e8f0; }
+  .kf { display: flex; flex-direction: column; }
+  .kf-label { font-size: .7rem; text-transform: uppercase; letter-spacing: .05em; color: #888; font-weight: 600; }
+  .kf-value { font-size: .95rem; font-weight: 600; color: #1a202c; }
   .field { margin-bottom: .35rem; font-size: .9rem; }
   .field b { display: inline-block; min-width: 160px; color: #555; }
   .section { margin-top: .8rem; padding-top: .6rem; border-top: 1px solid #eee; }
@@ -43,6 +49,9 @@ HTML = """<!DOCTYPE html>
   .entry { margin-left: 1rem; margin-bottom: .3rem; font-size: .85rem; color: #444; }
   .entry-type { font-weight: 600; color: #666; }
   .error { color: #c00; font-weight: 600; }
+  details { margin-top: .6rem; }
+  details summary { cursor: pointer; font-size: .9rem; font-weight: 600; color: #555; }
+  details summary:hover { color: #0066cc; }
 </style>
 </head>
 <body>
@@ -97,34 +106,62 @@ form.addEventListener('submit', async (e) => {
 
 function esc(s) { const d = document.createElement('div'); d.textContent = s; return d.innerHTML; }
 
-function renderCompany(c) {
-  let html = '<div class="card">';
-  html += '<h2>' + esc(c.name) + '</h2>';
-  html += field('Court', c.court);
-  html += field('Register', c.register_num);
-  html += field('State', c.state);
-  html += field('Status', c.statusCurrent);
+function extractState(court) {
+  // Court field starts with the state name, e.g. "Saxony   District court Leipzig HRB 32007"
+  if (!court) return null;
+  const m = court.match(/^(.+?)\\s{2,}/);
+  return m ? m[1].trim() : null;
+}
 
-  if (c.history && c.history.length) {
-    html += '<div class="section"><h3>History</h3>';
-    c.history.forEach(h => { html += '<div class="person">' + esc(h[0]) + ' &mdash; ' + esc(h[1]) + '</div>'; });
-    html += '</div>';
+function extractFoundingYear(detail) {
+  if (!detail) return null;
+  // Best source: earliest "Gesellschaftsvertrag vom DD.MM.YYYY" in register entries
+  if (detail.register_entries) {
+    for (const e of detail.register_entries) {
+      const m = (e.text || '').match(/Gesellschaftsvertrag\\s+vom\\s+\\d{2}\\.\\d{2}\\.(\\d{4})/);
+      if (m) return m[1];
+    }
   }
+  // Fallback: articles of association date
+  if (detail.articles_of_association_date) return detail.articles_of_association_date.split('-')[0];
+  return null;
+}
 
+function formatCapital(cap) {
+  if (!cap) return null;
+  const num = parseFloat(cap.amount);
+  if (isNaN(num)) return cap.amount + ' ' + cap.currency;
+  return num.toLocaleString('de-DE', { minimumFractionDigits: 2 }) + ' ' + cap.currency;
+}
+
+function renderCompany(c) {
   const d = c.detail;
+  const state = extractState(c.court) || c.state;
+  const foundingYear = extractFoundingYear(d);
+  const legalForm = (d && d.legal_form) || null;
+
+  let html = '<div class="card">';
+  html += '<h2>' + esc(d && d.name ? d.name : c.name) + '</h2>';
+
+  // Key facts grid — the four target fields
+  html += '<div class="key-facts">';
+  html += kf('Company Name', d && d.name ? d.name : c.name);
+  html += kf('Legal Form', legalForm);
+  html += kf('Founding Year', foundingYear);
+  html += kf('Headquarters State', state);
+  html += '</div>';
+
+  // Additional SI detail
   if (d) {
-    html += '<div class="section"><h3>Detail (SI)</h3>';
-    html += field('Legal Form', d.legal_form);
-    html += field('Seat', d.seat);
     if (d.address) {
       const a = d.address;
       const parts = [a.street, [a.postal_code, a.city].filter(Boolean).join(' ')].filter(Boolean);
       html += field('Address', parts.join(', '));
     }
-    if (d.capital) html += field('Capital', d.capital.amount + ' ' + d.capital.currency);
+    if (d.capital) html += field('Capital', formatCapital(d.capital));
     html += field('Business Purpose', d.business_purpose);
-    html += field('Representation', d.representation_rules);
-    html += field('Articles Date', d.articles_of_association_date);
+    html += field('Register', c.register_num);
+    html += field('Status', c.statusCurrent);
     html += field('Last Entry', d.last_entry_date);
 
     if (d.directors && d.directors.length) {
@@ -145,17 +182,43 @@ function renderCompany(c) {
       });
       html += '</div>';
     }
+
+    // Collapsible sections for verbose data
+    if (d.representation_rules) {
+      html += '<details><summary>Representation Rules</summary>';
+      html += '<div class="field" style="margin-top:.4rem">' + esc(d.representation_rules) + '</div></details>';
+    }
+    if (c.history && c.history.length) {
+      html += '<details><summary>History (' + c.history.length + ')</summary>';
+      c.history.forEach(h => { html += '<div class="person">' + esc(h[0]) + ' &mdash; ' + esc(h[1]) + '</div>'; });
+      html += '</details>';
+    }
     if (d.register_entries && d.register_entries.length) {
-      html += '<div class="section"><h3>Register Entries</h3>';
+      html += '<details><summary>Register Entries (' + d.register_entries.length + ')</summary>';
       d.register_entries.forEach(e => {
         html += '<div class="entry"><span class="entry-type">[' + esc(e.type || '') + ']</span> ' + esc(e.text || '') + '</div>';
       });
+      html += '</details>';
+    }
+  } else {
+    // No detail — show basic search result fields
+    html += field('Court', c.court);
+    html += field('Register', c.register_num);
+    html += field('Status', c.statusCurrent);
+    if (c.history && c.history.length) {
+      html += '<div class="section"><h3>History</h3>';
+      c.history.forEach(h => { html += '<div class="person">' + esc(h[0]) + ' &mdash; ' + esc(h[1]) + '</div>'; });
       html += '</div>';
     }
-    html += '</div>';
   }
+
   html += '</div>';
   return html;
+}
+
+function kf(label, val) {
+  return '<div class="kf"><span class="kf-label">' + esc(label) + '</span>'
+       + '<span class="kf-value">' + esc(val || '\u2014') + '</span></div>';
 }
 
 function field(label, val) {
@@ -219,6 +282,10 @@ class Handler(BaseHTTPRequestHandler):
         print('[%s] %s' % (self.log_date_time_string(), fmt % args))
 
 
+class ReusableHTTPServer(HTTPServer):
+    allow_reuse_address = True
+
+
 if __name__ == '__main__':
     print('Handelsregister Web UI running at http://localhost:%d' % PORT)
-    HTTPServer(('', PORT), Handler).serve_forever()
+    ReusableHTTPServer(('', PORT), Handler).serve_forever()

--- a/web.py
+++ b/web.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Minimal web UI for the Handelsregister CLI. No extra dependencies — uses stdlib only."""
+
+import json
+import argparse
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from urllib.parse import parse_qs
+from handelsregister import HandelsRegister, parse_si_detail
+
+PORT = 8000
+
+HTML = """<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Handelsregister Search</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+         background: #f5f5f5; color: #222; padding: 2rem; max-width: 900px; margin: 0 auto; }
+  h1 { margin-bottom: 1.5rem; font-size: 1.4rem; }
+  form { background: #fff; padding: 1.5rem; border-radius: 8px; box-shadow: 0 1px 3px rgba(0,0,0,.1);
+         display: flex; flex-wrap: wrap; gap: 1rem; align-items: end; margin-bottom: 2rem; }
+  label { display: flex; flex-direction: column; gap: .3rem; font-size: .85rem; font-weight: 600; }
+  input[type=text] { padding: .5rem .7rem; border: 1px solid #ccc; border-radius: 4px; font-size: .95rem; width: 280px; }
+  select { padding: .5rem; border: 1px solid #ccc; border-radius: 4px; font-size: .95rem; }
+  button { padding: .55rem 1.2rem; background: #0066cc; color: #fff; border: none; border-radius: 4px;
+           font-size: .95rem; cursor: pointer; }
+  button:hover { background: #0052a3; }
+  button:disabled { background: #999; cursor: wait; }
+  .cb { display: flex; align-items: center; gap: .4rem; font-weight: 600; font-size: .85rem; }
+  .cb input { width: auto; }
+  #status { font-size: .85rem; color: #666; margin-bottom: 1rem; min-height: 1.2em; }
+  #results { display: flex; flex-direction: column; gap: 1.5rem; }
+  .card { background: #fff; padding: 1.2rem 1.5rem; border-radius: 8px; box-shadow: 0 1px 3px rgba(0,0,0,.1); }
+  .card h2 { font-size: 1.1rem; margin-bottom: .6rem; color: #0066cc; }
+  .field { margin-bottom: .35rem; font-size: .9rem; }
+  .field b { display: inline-block; min-width: 160px; color: #555; }
+  .section { margin-top: .8rem; padding-top: .6rem; border-top: 1px solid #eee; }
+  .section h3 { font-size: .95rem; margin-bottom: .4rem; color: #333; }
+  .person { margin-left: 1rem; margin-bottom: .2rem; font-size: .9rem; }
+  .entry { margin-left: 1rem; margin-bottom: .3rem; font-size: .85rem; color: #444; }
+  .entry-type { font-weight: 600; color: #666; }
+  .error { color: #c00; font-weight: 600; }
+</style>
+</head>
+<body>
+<h1>Handelsregister Search</h1>
+<form id="searchForm">
+  <label>Company name
+    <input type="text" name="q" placeholder="e.g. Gecko Two GmbH" required>
+  </label>
+  <label>Match
+    <select name="so">
+      <option value="all">All keywords</option>
+      <option value="min">At least one</option>
+      <option value="exact" selected>Exact name</option>
+    </select>
+  </label>
+  <label class="cb"><input type="checkbox" name="detail" checked> Fetch detail (SI)</label>
+  <button type="submit" id="btn">Search</button>
+</form>
+<div id="status"></div>
+<div id="results"></div>
+
+<script>
+const form = document.getElementById('searchForm');
+const btn = document.getElementById('btn');
+const status = document.getElementById('status');
+const results = document.getElementById('results');
+
+form.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const fd = new FormData(form);
+  const params = new URLSearchParams();
+  params.set('q', fd.get('q'));
+  params.set('so', fd.get('so'));
+  params.set('detail', fd.has('detail') ? '1' : '0');
+
+  btn.disabled = true;
+  status.textContent = 'Searching...';
+  results.innerHTML = '';
+
+  try {
+    const resp = await fetch('/api/search?' + params.toString());
+    const data = await resp.json();
+    if (data.error) { status.innerHTML = '<span class="error">' + esc(data.error) + '</span>'; return; }
+    status.textContent = data.companies.length + ' result(s)';
+    results.innerHTML = data.companies.map(renderCompany).join('');
+  } catch (err) {
+    status.innerHTML = '<span class="error">Request failed: ' + esc(err.message) + '</span>';
+  } finally {
+    btn.disabled = false;
+  }
+});
+
+function esc(s) { const d = document.createElement('div'); d.textContent = s; return d.innerHTML; }
+
+function renderCompany(c) {
+  let html = '<div class="card">';
+  html += '<h2>' + esc(c.name) + '</h2>';
+  html += field('Court', c.court);
+  html += field('Register', c.register_num);
+  html += field('State', c.state);
+  html += field('Status', c.statusCurrent);
+
+  if (c.history && c.history.length) {
+    html += '<div class="section"><h3>History</h3>';
+    c.history.forEach(h => { html += '<div class="person">' + esc(h[0]) + ' &mdash; ' + esc(h[1]) + '</div>'; });
+    html += '</div>';
+  }
+
+  const d = c.detail;
+  if (d) {
+    html += '<div class="section"><h3>Detail (SI)</h3>';
+    html += field('Legal Form', d.legal_form);
+    html += field('Seat', d.seat);
+    if (d.address) {
+      const a = d.address;
+      const parts = [a.street, [a.postal_code, a.city].filter(Boolean).join(' ')].filter(Boolean);
+      html += field('Address', parts.join(', '));
+    }
+    if (d.capital) html += field('Capital', d.capital.amount + ' ' + d.capital.currency);
+    html += field('Business Purpose', d.business_purpose);
+    html += field('Representation', d.representation_rules);
+    html += field('Articles Date', d.articles_of_association_date);
+    html += field('Last Entry', d.last_entry_date);
+
+    if (d.directors && d.directors.length) {
+      html += '<div class="section"><h3>Directors</h3>';
+      d.directors.forEach(p => {
+        let s = esc(p.name || '?');
+        if (p.representation) s += ' (' + esc(p.representation) + ')';
+        html += '<div class="person">' + s + '</div>';
+      });
+      html += '</div>';
+    }
+    if (d.prokura && d.prokura.length) {
+      html += '<div class="section"><h3>Prokura</h3>';
+      d.prokura.forEach(p => {
+        let s = esc(p.name || '?');
+        if (p.representation) s += ' (' + esc(p.representation) + ')';
+        html += '<div class="person">' + s + '</div>';
+      });
+      html += '</div>';
+    }
+    if (d.register_entries && d.register_entries.length) {
+      html += '<div class="section"><h3>Register Entries</h3>';
+      d.register_entries.forEach(e => {
+        html += '<div class="entry"><span class="entry-type">[' + esc(e.type || '') + ']</span> ' + esc(e.text || '') + '</div>';
+      });
+      html += '</div>';
+    }
+    html += '</div>';
+  }
+  html += '</div>';
+  return html;
+}
+
+function field(label, val) {
+  if (!val) return '';
+  return '<div class="field"><b>' + esc(label) + '</b> ' + esc(val) + '</div>';
+}
+</script>
+</body>
+</html>"""
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == '/' or self.path == '/index.html':
+            self.send_response(200)
+            self.send_header('Content-Type', 'text/html; charset=utf-8')
+            self.end_headers()
+            self.wfile.write(HTML.encode())
+        elif self.path.startswith('/api/search'):
+            self.handle_search()
+        else:
+            self.send_error(404)
+
+    def handle_search(self):
+        qs = parse_qs(self.path.split('?', 1)[1]) if '?' in self.path else {}
+        query = qs.get('q', [''])[0].strip()
+        so = qs.get('so', ['exact'])[0]
+        detail = qs.get('detail', ['0'])[0] == '1'
+
+        if not query:
+            self.json_response({'error': 'No search query provided'})
+            return
+
+        try:
+            args = argparse.Namespace(
+                debug=False, force=True, schlagwoerter=query,
+                schlagwortOptionen=so, json=True, detail=detail
+            )
+            h = HandelsRegister(args)
+            h.open_startpage()
+            companies = h.search_company()
+
+            if detail and companies:
+                d = h.fetch_company_detail(result_index=0)
+                if d:
+                    companies[0]['detail'] = d
+
+            self.json_response({'companies': companies})
+        except Exception as e:
+            self.json_response({'error': str(e)})
+
+    def json_response(self, data):
+        body = json.dumps(data, ensure_ascii=False).encode()
+        self.send_response(200)
+        self.send_header('Content-Type', 'application/json; charset=utf-8')
+        self.send_header('Content-Length', str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, fmt, *args):
+        print('[%s] %s' % (self.log_date_time_string(), fmt % args))
+
+
+if __name__ == '__main__':
+    print('Handelsregister Web UI running at http://localhost:%d' % PORT)
+    HTTPServer(('', PORT), Handler).serve_forever()

--- a/web.py
+++ b/web.py
@@ -18,7 +18,7 @@ HTML = """<!DOCTYPE html>
 <style>
   * { box-sizing: border-box; margin: 0; padding: 0; }
   body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-         background: #f5f5f5; color: #222; padding: 2rem; max-width: 960px; margin: 0 auto; }
+         background: #f5f5f5; color: #222; padding: 2rem; max-width: 900px; margin: 0 auto; }
   h1 { margin-bottom: 1.5rem; font-size: 1.4rem; }
   form { background: #fff; padding: 1.5rem; border-radius: 8px; box-shadow: 0 1px 3px rgba(0,0,0,.1);
          display: flex; flex-wrap: wrap; gap: 1rem; align-items: end; margin-bottom: 2rem; }
@@ -34,13 +34,7 @@ HTML = """<!DOCTYPE html>
   #status { font-size: .85rem; color: #666; margin-bottom: 1rem; min-height: 1.2em; }
   #results { display: flex; flex-direction: column; gap: 1.5rem; }
   .card { background: #fff; padding: 1.2rem 1.5rem; border-radius: 8px; box-shadow: 0 1px 3px rgba(0,0,0,.1); }
-  .card h2 { font-size: 1.2rem; margin-bottom: .8rem; color: #0066cc; }
-  .key-facts { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-               gap: .6rem; margin-bottom: 1rem; padding: .8rem; background: #f8fafc;
-               border-radius: 6px; border: 1px solid #e2e8f0; }
-  .kf { display: flex; flex-direction: column; }
-  .kf-label { font-size: .7rem; text-transform: uppercase; letter-spacing: .05em; color: #888; font-weight: 600; }
-  .kf-value { font-size: .95rem; font-weight: 600; color: #1a202c; }
+  .card h2 { font-size: 1.1rem; margin-bottom: .6rem; color: #0066cc; }
   .field { margin-bottom: .35rem; font-size: .9rem; }
   .field b { display: inline-block; min-width: 160px; color: #555; }
   .section { margin-top: .8rem; padding-top: .6rem; border-top: 1px solid #eee; }
@@ -49,9 +43,6 @@ HTML = """<!DOCTYPE html>
   .entry { margin-left: 1rem; margin-bottom: .3rem; font-size: .85rem; color: #444; }
   .entry-type { font-weight: 600; color: #666; }
   .error { color: #c00; font-weight: 600; }
-  details { margin-top: .6rem; }
-  details summary { cursor: pointer; font-size: .9rem; font-weight: 600; color: #555; }
-  details summary:hover { color: #0066cc; }
 </style>
 </head>
 <body>
@@ -106,62 +97,34 @@ form.addEventListener('submit', async (e) => {
 
 function esc(s) { const d = document.createElement('div'); d.textContent = s; return d.innerHTML; }
 
-function extractState(court) {
-  // Court field starts with the state name, e.g. "Saxony   District court Leipzig HRB 32007"
-  if (!court) return null;
-  const m = court.match(/^(.+?)\\s{2,}/);
-  return m ? m[1].trim() : null;
-}
-
-function extractFoundingYear(detail) {
-  if (!detail) return null;
-  // Best source: earliest "Gesellschaftsvertrag vom DD.MM.YYYY" in register entries
-  if (detail.register_entries) {
-    for (const e of detail.register_entries) {
-      const m = (e.text || '').match(/Gesellschaftsvertrag\\s+vom\\s+\\d{2}\\.\\d{2}\\.(\\d{4})/);
-      if (m) return m[1];
-    }
-  }
-  // Fallback: articles of association date
-  if (detail.articles_of_association_date) return detail.articles_of_association_date.split('-')[0];
-  return null;
-}
-
-function formatCapital(cap) {
-  if (!cap) return null;
-  const num = parseFloat(cap.amount);
-  if (isNaN(num)) return cap.amount + ' ' + cap.currency;
-  return num.toLocaleString('de-DE', { minimumFractionDigits: 2 }) + ' ' + cap.currency;
-}
-
 function renderCompany(c) {
-  const d = c.detail;
-  const state = extractState(c.court) || c.state;
-  const foundingYear = extractFoundingYear(d);
-  const legalForm = (d && d.legal_form) || null;
-
   let html = '<div class="card">';
-  html += '<h2>' + esc(d && d.name ? d.name : c.name) + '</h2>';
+  html += '<h2>' + esc(c.name) + '</h2>';
+  html += field('Court', c.court);
+  html += field('Register', c.register_num);
+  html += field('State', c.state);
+  html += field('Status', c.statusCurrent);
 
-  // Key facts grid — the four target fields
-  html += '<div class="key-facts">';
-  html += kf('Company Name', d && d.name ? d.name : c.name);
-  html += kf('Legal Form', legalForm);
-  html += kf('Founding Year', foundingYear);
-  html += kf('Headquarters State', state);
-  html += '</div>';
+  if (c.history && c.history.length) {
+    html += '<div class="section"><h3>History</h3>';
+    c.history.forEach(h => { html += '<div class="person">' + esc(h[0]) + ' &mdash; ' + esc(h[1]) + '</div>'; });
+    html += '</div>';
+  }
 
-  // Additional SI detail
+  const d = c.detail;
   if (d) {
+    html += '<div class="section"><h3>Detail (SI)</h3>';
+    html += field('Legal Form', d.legal_form);
+    html += field('Seat', d.seat);
     if (d.address) {
       const a = d.address;
       const parts = [a.street, [a.postal_code, a.city].filter(Boolean).join(' ')].filter(Boolean);
       html += field('Address', parts.join(', '));
     }
-    if (d.capital) html += field('Capital', formatCapital(d.capital));
+    if (d.capital) html += field('Capital', d.capital.amount + ' ' + d.capital.currency);
     html += field('Business Purpose', d.business_purpose);
-    html += field('Register', c.register_num);
-    html += field('Status', c.statusCurrent);
+    html += field('Representation', d.representation_rules);
+    html += field('Articles Date', d.articles_of_association_date);
     html += field('Last Entry', d.last_entry_date);
 
     if (d.directors && d.directors.length) {
@@ -182,43 +145,17 @@ function renderCompany(c) {
       });
       html += '</div>';
     }
-
-    // Collapsible sections for verbose data
-    if (d.representation_rules) {
-      html += '<details><summary>Representation Rules</summary>';
-      html += '<div class="field" style="margin-top:.4rem">' + esc(d.representation_rules) + '</div></details>';
-    }
-    if (c.history && c.history.length) {
-      html += '<details><summary>History (' + c.history.length + ')</summary>';
-      c.history.forEach(h => { html += '<div class="person">' + esc(h[0]) + ' &mdash; ' + esc(h[1]) + '</div>'; });
-      html += '</details>';
-    }
     if (d.register_entries && d.register_entries.length) {
-      html += '<details><summary>Register Entries (' + d.register_entries.length + ')</summary>';
+      html += '<div class="section"><h3>Register Entries</h3>';
       d.register_entries.forEach(e => {
         html += '<div class="entry"><span class="entry-type">[' + esc(e.type || '') + ']</span> ' + esc(e.text || '') + '</div>';
       });
-      html += '</details>';
-    }
-  } else {
-    // No detail — show basic search result fields
-    html += field('Court', c.court);
-    html += field('Register', c.register_num);
-    html += field('Status', c.statusCurrent);
-    if (c.history && c.history.length) {
-      html += '<div class="section"><h3>History</h3>';
-      c.history.forEach(h => { html += '<div class="person">' + esc(h[0]) + ' &mdash; ' + esc(h[1]) + '</div>'; });
       html += '</div>';
     }
+    html += '</div>';
   }
-
   html += '</div>';
   return html;
-}
-
-function kf(label, val) {
-  return '<div class="kf"><span class="kf-label">' + esc(label) + '</span>'
-       + '<span class="kf-value">' + esc(val || '\u2014') + '</span></div>';
 }
 
 function field(label, val) {
@@ -282,10 +219,6 @@ class Handler(BaseHTTPRequestHandler):
         print('[%s] %s' % (self.log_date_time_string(), fmt % args))
 
 
-class ReusableHTTPServer(HTTPServer):
-    allow_reuse_address = True
-
-
 if __name__ == '__main__':
     print('Handelsregister Web UI running at http://localhost:%d' % PORT)
-    ReusableHTTPServer(('', PORT), Handler).serve_forever()
+    HTTPServer(('', PORT), Handler).serve_forever()


### PR DESCRIPTION
## Summary

- Adds `--detail` / `-det` CLI flag that fetches the SI (Strukturierter Registerinhalt) XJustiz XML document for the first search result
- Parses company name, address, legal form, share capital, directors, prokura holders, business purpose, representation rules, and register entry history
- Works with both text and JSON (`-j`) output modes
- Includes unit test (`test_parse_si_detail`) and integration test (`test_fetch_detail`)

Closes #1

## Test plan

- [ ] `python handelsregister.py -s "Gecko Two GmbH" -so exact --detail -f` — verify enriched output
- [ ] `python handelsregister.py -s "Gecko Two GmbH" -so exact --detail -f -j` — verify JSON includes `detail` key
- [ ] `python handelsregister.py -s "Gecko Two GmbH" -so exact -f` — verify no regression without `--detail`
- [ ] `pytest test_handelsregister.py::test_parse_si_detail` — unit test passes
- [ ] `pytest test_handelsregister.py::test_fetch_detail` — integration test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)